### PR TITLE
fix: npm i, test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,5 @@
+npm i
+
 # provide execution permission.
 chmod +x ./bash/run-bash.sh
 chmod +x ./python/run-python.sh


### PR DESCRIPTION
The current test.sh file is missing the npm install command, which can cause issues like jest not being found.